### PR TITLE
Prepare for hex.pm publication

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Jechol Lee <jechol@devall.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule FeistelCipher.MixProject do
       consolidate_protocols: Mix.env() not in [:dev, :test],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      description: "A Ecto migration for Feistel cipher",
+      description: "An Ecto migration for Feistel cipher",
       package: package(),
       source_url: "https://github.com/devall-org/feistel_cipher",
       homepage_url: "https://github.com/devall-org/feistel_cipher",
@@ -45,9 +45,11 @@ defmodule FeistelCipher.MixProject do
     [
       name: "feistel_cipher",
       licenses: ["MIT"],
+      maintainers: ["Jechol Lee"],
       links: %{
         "GitHub" => "https://github.com/devall-org/feistel_cipher"
-      }
+      },
+      files: ~w(lib priv mix.exs README.md LICENSE)
     ]
   end
 end


### PR DESCRIPTION
## Changes

- Add MIT LICENSE file with copyright information
- Fix description grammar ('A Ecto' → 'An Ecto')
- Add maintainer information (Jechol Lee)
- Add explicit files list to package configuration (including priv directory for database functions)

## Purpose

This PR prepares the package for publication to hex.pm with all required metadata and licensing information.