### PR TITLE
fix: remove formatter import_dep from installer

### DIFF
--- a/lib/install.ex
+++ b/lib/install.ex
@@ -72,7 +72,6 @@ if Code.ensure_loaded?(Igniter) do
 
           # Feistel cipher first published on May 1, 1973 (Horst Feistel, "Cryptography and Computer Privacy", Scientific American)
           igniter
-          |> Igniter.Project.Formatter.import_dep(:feistel_cipher)
           |> Igniter.Libs.Ecto.gen_migration(repo, "add_feistel_cipher",
             timestamp: "19730501000000",
             body: migration,


### PR DESCRIPTION
## Problem

When users run \`mix igniter.install feistel_cipher\` (or transitively via \`ash_feistel_cipher\`), the installer was adding \`feistel_cipher\` to their project's formatter \`import_deps\`.

However, this package doesn't provide any user-facing DSL that requires special formatting, so there's no need to modify user projects' formatter configuration.

## Solution

Remove the \`Igniter.Project.Formatter.import_dep(:feistel_cipher)\` call from the installer.

## Benefits

- ✅ User projects' formatter settings remain untouched
- ✅ Cleaner installation process
- ✅ No unnecessary formatter dependencies