### PR TITLE
fix: remove non-existent priv directory from package files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule FeistelCipher.MixProject do
       links: %{
         "GitHub" => "https://github.com/devall-org/feistel_cipher"
       },
-      files: ~w(lib priv mix.exs README.md LICENSE)
+      files: ~w(lib mix.exs README.md LICENSE)
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule FeistelCipher.MixProject do
       links: %{
         "GitHub" => "https://github.com/devall-org/feistel_cipher"
       },
-      files: ~w(lib mix.exs README.md LICENSE)
+      files: ~w(lib priv mix.exs README.md LICENSE)
     ]
   end
 end


### PR DESCRIPTION
## Problem

`mix hex.publish` failed with error:
```
Missing files: priv
```

The `priv` directory does not exist in the project but was listed in the package files.

## Solution

Remove `priv` from the `files` list in `mix.exs`:
```elixir
# Before
files: ~w(lib priv mix.exs README.md LICENSE)

# After
files: ~w(lib mix.exs README.md LICENSE)
```

## Testing

- `mix hex.build` succeeds without errors
- Package checksum generated successfully
