### PR TITLE
Allow up to 63 total bits when `encrypt_time` is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The `up_for_trigger/5` function accepts these options:
 - `functions_prefix`: Schema where cipher functions reside (default: `public`)
 
 **Constraints**:
-- `time_bits + data_bits` must be ≤ 62
+- `time_bits + data_bits` must be ≤ 63 when `encrypt_time: false`, and ≤ 62 when `encrypt_time: true`
 - `time_bits` must be even when `encrypt_time: true`
 - `data_bits` must be even and ≥ 2
 

--- a/lib/feistel_cipher.ex
+++ b/lib/feistel_cipher.ex
@@ -311,9 +311,11 @@ defmodule FeistelCipher do
       raise ArgumentError, "data_bits must be at least 2, got: #{data_bits}"
     end
 
-    unless time_bits + data_bits <= 62 do
+    max_total_bits = if encrypt_time, do: 62, else: 63
+
+    unless time_bits + data_bits <= max_total_bits do
       raise ArgumentError,
-            "time_bits + data_bits must be <= 62, got: #{time_bits} + #{data_bits} = #{time_bits + data_bits}"
+            "time_bits + data_bits must be <= #{max_total_bits} when encrypt_time is #{encrypt_time}, got: #{time_bits} + #{data_bits} = #{time_bits + data_bits}"
     end
 
     rounds = Keyword.get(opts, :rounds, 16)

--- a/test/feistel_cipher_test.exs
+++ b/test/feistel_cipher_test.exs
@@ -970,13 +970,40 @@ defmodule FeistelCipher.MigrationTest do
       end
     end
 
-    test "raises when time_bits + data_bits > 62" do
-      assert_raise ArgumentError, ~r/time_bits \+ data_bits must be <= 62/, fn ->
+    test "allows time_bits + data_bits = 63 when encrypt_time is false" do
+      sql =
         FeistelCipher.up_for_trigger("public", "users", "seq", "id",
-          time_bits: 12,
-          data_bits: 52
+          time_bits: 13,
+          data_bits: 50,
+          encrypt_time: false
         )
-      end
+
+      assert sql =~ ", 13,"
+      assert sql =~ ", false, 50,"
+    end
+
+    test "raises when time_bits + data_bits > 63 and encrypt_time is false" do
+      assert_raise ArgumentError,
+                   ~r/time_bits \+ data_bits must be <= 63 when encrypt_time is false/,
+                   fn ->
+                     FeistelCipher.up_for_trigger("public", "users", "seq", "id",
+                       time_bits: 14,
+                       data_bits: 50,
+                       encrypt_time: false
+                     )
+                   end
+    end
+
+    test "raises when time_bits + data_bits > 62 and encrypt_time is true" do
+      assert_raise ArgumentError,
+                   ~r/time_bits \+ data_bits must be <= 62 when encrypt_time is true/,
+                   fn ->
+                     FeistelCipher.up_for_trigger("public", "users", "seq", "id",
+                       time_bits: 12,
+                       data_bits: 52,
+                       encrypt_time: true
+                     )
+                   end
     end
 
     test "raises when encrypt_time: true and time_bits < 2" do


### PR DESCRIPTION
### Motivation

- The total bit limit for generated IDs was fixed to 62, but when `encrypt_time: false` the `time_bits` prefix may be odd and an extra usable bit is available, so the combined `time_bits + data_bits` can be up to 63.  
- We must preserve the stricter 62-bit cap when `encrypt_time: true` because encrypted time must remain splittable/even for the Feistel halves. 

### Description

- Updated `up_for_trigger/5` validation in `lib/feistel_cipher.ex` to compute `max_total_bits = if encrypt_time, do: 62, else: 63` and validate `time_bits + data_bits <= max_total_bits`.  
- Improved the validation error message to include the mode-specific `max_total_bits` and the current `encrypt_time` value.  
- Added/modified unit tests in `test/feistel_cipher_test.exs` to cover: allowing `time_bits + data_bits = 63` when `encrypt_time: false`, rejecting totals > 63 when `encrypt_time: false`, and rejecting totals > 62 when `encrypt_time: true`.  
- Updated `README.md` constraints to document the conditional total-bit limit: "≤ 63 when `encrypt_time: false`, and ≤ 62 when `encrypt_time: true`."

### Testing

- Ran `mix format lib/feistel_cipher.ex test/feistel_cipher_test.exs` with no issues.  
- Ran `mix test test/feistel_cipher_test.exs` and all tests passed (`38 tests, 0 failures`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e438c98d88333a4ffc51ffbd64725)