### PR TITLE
Allow zero-length bits for Feistel cipher (data_bits/time bits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The `up_for_trigger/5` function accepts these options:
 **Constraints**:
 - `time_bits + data_bits` must be ≤ 62
 - `time_bits` must be even when `encrypt_time: true`
-- `data_bits` must be even and ≥ 2
+- `data_bits` must be even
 
 Example with custom options:
 ```elixir

--- a/lib/feistel_cipher.ex
+++ b/lib/feistel_cipher.ex
@@ -82,8 +82,8 @@ defmodule FeistelCipher do
         hash_int   bigint;
 
       BEGIN
-        IF bits < 2 OR bits > 62 OR bits % 2 = 1 THEN
-          RAISE EXCEPTION 'feistel_cipher: bits must be an even number between 2 and 62: %', bits;
+        IF bits < 0 OR bits > 62 OR bits % 2 = 1 THEN
+          RAISE EXCEPTION 'feistel_cipher: bits must be an even number between 0 and 62: %', bits;
         END IF;
 
         IF key < 0 OR key >= (1::bigint << 31) THEN
@@ -307,8 +307,8 @@ defmodule FeistelCipher do
       raise ArgumentError, "data_bits must be an even number, got: #{data_bits}"
     end
 
-    unless data_bits >= 2 do
-      raise ArgumentError, "data_bits must be at least 2, got: #{data_bits}"
+    unless data_bits >= 0 do
+      raise ArgumentError, "data_bits must be non-negative, got: #{data_bits}"
     end
 
     unless time_bits + data_bits <= 62 do


### PR DESCRIPTION
### Motivation
- Relax constraints to permit zero-length bit fields so callers can disable time/data prefixes or use 0-bit columns without workarounds.

### Description
- Allow `bits` = 0 in the PostgreSQL `feistel_cipher` implementation and adjust the error message to reflect the new range (`0..62`).
- Relax Elixir validation in `FeistelCipher.up_for_trigger` to permit `data_bits >= 0` and update the error text accordingly.
- Update tests to cover the zero-bit case by expanding the tested bit sizes to include `0`, replace the invalid-bits check with a negative value, add a `handles zero bits as 0 -> 0 identity` test, and add tests for `data_bits = 0` and negative `data_bits` validation; adjust an SQL substring assertion to include the zero `data_bits` value.
- Update `README.md` to remove the `>= 2` requirement for `data_bits` in the constraints section.

### Testing
- Ran the test suite with `mix test`; all tests completed and passed.
- New and modified unit tests covering zero-bit encryption/decryption, invalid negative bit/key/round values, and `data_bits` boundary cases were executed and succeeded.
- Existing permutation, NULL handling, and trigger SQL generation tests were run and passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4405f4548333b9a37917bc5911e2)