### PR TITLE
Fix docs and use FeistelCipher.generate_random_salt for default salt

### DIFF
--- a/lib/install.ex
+++ b/lib/install.ex
@@ -2,11 +2,11 @@ defmodule Mix.Tasks.FeistelCipher.Install.Docs do
   @moduledoc false
 
   def short_doc do
-    "A Ecto migration for Feistel cipher"
+    "An Ecto migration for Feistel cipher"
   end
 
   def example do
-    "mix igniter.install feistel_cipher"
+    "mix feistel_cipher.install"
   end
 
   def long_doc do
@@ -46,16 +46,11 @@ if Code.ensure_loaded?(Igniter) do
         schema: [repo: :string, functions_prefix: :string, functions_salt: :integer],
         defaults: [
           functions_prefix: "public",
-          functions_salt: generate_random_salt()
+          functions_salt: FeistelCipher.generate_random_salt()
         ],
         aliases: [r: :repo, p: :functions_prefix, s: :functions_salt],
         required: []
       }
-    end
-
-    defp generate_random_salt do
-      <<salt::31, _::1>> = :crypto.strong_rand_bytes(4)
-      salt
     end
 
     @impl Igniter.Mix.Task


### PR DESCRIPTION
### Motivation

- Correct wording and example for the Feistel cipher install task to improve clarity in the mix task docs.  
- Centralize random salt generation by delegating to `FeistelCipher.generate_random_salt/0` to avoid duplicated logic in the mix task.

### Description

- Update the short documentation string from "A Ecto migration for Feistel cipher" to "An Ecto migration for Feistel cipher".  
- Replace the example invocation from `mix igniter.install feistel_cipher` to `mix feistel_cipher.install`.  
- Use `FeistelCipher.generate_random_salt()` as the default `functions_salt` and remove the local `generate_random_salt/0` helper.

### Testing

- Ran `mix compile` to ensure the project builds successfully and it succeeded.  
- Ran the existing test suite with `mix test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4cbc8ad083339276401bc8c6a58b)