### PR TITLE
Release v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,44 +66,9 @@ Both methods support the following options:
 > **Fun Fact**: Notice the timestamp `19730501000000` in the migration file generated during installation? That's May 1, 1973 - the day [Horst Feistel published his groundbreaking paper](https://en.wikipedia.org/wiki/Feistel_cipher#History) at IBM, introducing the cipher structure that powers this library. We thought it deserved a permanent timestamp in your database history! 🎂
 
 
-## Upgrading from v0.x to v1.0
+## Upgrading from v0.x
 
-v1.0 introduces time-based prefixes and renames `bits` to `data_bits`. The new PostgreSQL functions use a `_v1` suffix (`feistel_cipher_v1`, `feistel_column_trigger_v1`), so they coexist with the old ones during migration.
-
-### Quick Guide
-
-1. **Update dependency** to `~> 1.0`
-
-2. **Run the upgrade task** to generate a database migration:
-
-```bash
-mix feistel_cipher.upgrade
-```
-
-3. **Edit the generated migration** — fill in your `functions_salt` and trigger details:
-
-```elixir
-def up do
-  # Step 1: Install v1 functions (coexists with old ones)
-  FeistelCipher.up_for_functions(functions_prefix: "public", functions_salt: YOUR_SALT)
-
-  # Step 2: For each trigger, drop old and recreate with v1
-  #   bits: N  →  time_bits: 0, data_bits: N
-  #   (old default for bits was 52)
-  execute FeistelCipher.force_down_for_trigger("public", "posts", "seq", "id")
-  execute FeistelCipher.up_for_trigger("public", "posts", "seq", "id",
-    time_bits: 0, data_bits: 52, functions_prefix: "public")
-
-  # Step 3 (optional): Drop old functions
-  execute "DROP FUNCTION IF EXISTS public.feistel_cipher(bigint, int, bigint, int)"
-  execute "DROP FUNCTION IF EXISTS public.feistel_column_trigger()"
-end
-```
-
-**Key changes**:
-- `bits: N` → `time_bits: 0, data_bits: N` (use `time_bits: 0` for backward compatibility)
-- `time_offset` option removed
-- Find your `functions_salt` in the migration with timestamp `19730501000000`
+See [UPGRADE.md](UPGRADE.md) for the migration guide.
 
 ## Usage Example
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,74 @@
+# Upgrading FeistelCipher
+
+## From v0.15.0 to v1.0.0
+
+v0.15.0 → v1.0.0 is **fully backward compatible** when using `time_bits: 0`. The cipher algorithm is identical; only the API and PostgreSQL function names changed.
+
+### What changed
+
+- **PG function names**: `feistel_cipher` → `feistel_cipher_v1`, `feistel_column_trigger` → `feistel_column_trigger_v1`. Old functions are left untouched so they coexist during upgrade.
+- **`bits` option renamed to `data_bits`** (default changed from 52 to 40)
+- **New `time_bits` option** (default: 12) for time-based prefix. Use `time_bits: 0` to keep the old behavior.
+- **`time_offset` option removed**
+- **New options**: `time_bucket` (default: 86400), `encrypt_time` (default: false)
+
+### Steps
+
+1. Update dependency to `~> 1.0`
+
+2. Run the upgrade task to generate a database migration:
+
+```bash
+mix feistel_cipher.upgrade
+```
+
+3. Edit the generated migration — fill in your `functions_salt` and trigger details:
+
+```elixir
+def up do
+  # Step 1: Install v1 functions (coexists with old ones)
+  # Find your functions_salt in the migration with timestamp 19730501000000.
+  FeistelCipher.up_for_functions(functions_prefix: "public", functions_salt: YOUR_SALT)
+
+  # Step 2: For each trigger, drop old and recreate with v1
+  #   bits: N  →  time_bits: 0, data_bits: N
+  #   (old default for bits was 52)
+  execute FeistelCipher.force_down_for_trigger("public", "posts", "seq", "id")
+  execute FeistelCipher.up_for_trigger("public", "posts", "seq", "id",
+    time_bits: 0, data_bits: 52, functions_prefix: "public")
+
+  # Step 3 (optional): Drop old functions after all triggers are upgraded
+  execute "DROP FUNCTION IF EXISTS public.feistel_cipher(bigint, int, bigint, int)"
+  execute "DROP FUNCTION IF EXISTS public.feistel_column_trigger()"
+end
+
+def down do
+  raise "Irreversible migration"
+end
+```
+
+4. Run `mix ecto.migrate`
+
+---
+
+## From v0.14.0 or earlier to v1.0.0
+
+v0.14.0 → v0.15.0 introduced a **breaking change to the cipher algorithm**: the round function was hardened from a simple hash to HMAC-SHA256. This means **encryption results are different** — the same input produces different output.
+
+### Impact
+
+- **Existing encrypted data remains valid** as long as the old PostgreSQL functions (`feistel_cipher`) stay in the database.
+- **New rows will use `feistel_cipher_v1`** which produces different encrypted values than the old `feistel_cipher` for the same input.
+- There are **no primary key collisions** because both old and new functions are bijective (one-to-one mapping) within their bit range. The old function maps input space A → output space A (a permutation), and the new function maps input space A → output space A (a different permutation). Since each is collision-free independently, mixing them does not cause collisions.
+- However, the **1:1 reversibility property is lost for old rows**: calling `feistel_cipher_v1(old_encrypted_id)` will NOT return the original `seq` value.
+
+### When this matters
+
+- If your application **decrypts IDs** (e.g., `id → seq` lookup using the cipher function), old rows will decrypt incorrectly with the new function.
+- If your application only uses encrypted IDs as **opaque identifiers** (lookup by `id` directly), this is not an issue.
+
+### Steps
+
+Follow the same steps as "From v0.15.0 to v1.0.0" above. The upgrade task works the same way.
+
+If you need to maintain decryption capability for old rows, keep the old `feistel_cipher` function in the database (skip Step 3) and use it for decrypting pre-upgrade data.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -37,9 +37,20 @@ def up do
   execute FeistelCipher.up_for_trigger("public", "posts", "seq", "id",
     time_bits: 0, data_bits: 52, functions_prefix: "public")
 
-  # Step 3 (optional): Drop old functions after all triggers are upgraded
+  # Step 3 (optional): Drop old functions after all triggers are upgraded.
+  # Which functions exist depends on which version you're upgrading from:
+  #
+  # v0.15.0:
   execute "DROP FUNCTION IF EXISTS public.feistel_cipher(bigint, int, bigint, int)"
   execute "DROP FUNCTION IF EXISTS public.feistel_column_trigger()"
+  #
+  # v0.14.0:
+  # execute "DROP FUNCTION IF EXISTS public.feistel_encrypt(bigint, int, bigint, int)"
+  # execute "DROP FUNCTION IF EXISTS public.feistel_column_trigger()"
+  #
+  # v0.4.x or earlier:
+  # execute "DROP FUNCTION IF EXISTS public.feistel(bigint, int, bigint)"
+  # execute "DROP FUNCTION IF EXISTS public.handle_feistel_encryption()"
 end
 
 def down do

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,8 +1,8 @@
 # Upgrading FeistelCipher
 
-## From v0.15.0 to v1.0.0
+## From v0.14.0 or v0.15.0 to v1.0.0
 
-v0.15.0 → v1.0.0 is **fully backward compatible** when using `time_bits: 0`. The cipher algorithm is identical; only the API and PostgreSQL function names changed.
+v0.14.0/v0.15.0 → v1.0.0 is **fully backward compatible** when using `time_bits: 0`. The cipher algorithm (HMAC-SHA256) is identical; only the API and PostgreSQL function names changed.
 
 ### What changed
 
@@ -51,9 +51,9 @@ end
 
 ---
 
-## From v0.14.0 or earlier to v1.0.0
+## From v0.13.x or earlier to v1.0.0
 
-v0.14.0 → v0.15.0 introduced a **breaking change to the cipher algorithm**: the round function was hardened from a simple hash to HMAC-SHA256. This means **encryption results are different** — the same input produces different output.
+v0.14.0 introduced a **breaking change to the cipher algorithm**: the round function was hardened from a simple hash to HMAC-SHA256. This means **encryption results are different** — the same input produces different output.
 
 ### Impact
 
@@ -69,6 +69,6 @@ v0.14.0 → v0.15.0 introduced a **breaking change to the cipher algorithm**: th
 
 ### Steps
 
-Follow the same steps as "From v0.15.0 to v1.0.0" above. The upgrade task works the same way.
+Follow the same steps as "From v0.14.0 or v0.15.0 to v1.0.0" above. The upgrade task works the same way.
 
 If you need to maintain decryption capability for old rows, keep the old `feistel_cipher` function in the database (skip Step 3) and use it for decrypting pre-upgrade data.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -48,7 +48,7 @@ def up do
   # execute "DROP FUNCTION IF EXISTS public.feistel_encrypt(bigint, int, bigint, int)"
   # execute "DROP FUNCTION IF EXISTS public.feistel_column_trigger()"
   #
-  # v0.4.x or earlier:
+  # v0.13.x or earlier:
   # execute "DROP FUNCTION IF EXISTS public.feistel(bigint, int, bigint)"
   # execute "DROP FUNCTION IF EXISTS public.handle_feistel_encryption()"
 end

--- a/lib/upgrade.ex
+++ b/lib/upgrade.ex
@@ -98,7 +98,7 @@ if Code.ensure_loaded?(Igniter) do
             #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel_encrypt(bigint, int, bigint, int)"
             #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel_column_trigger()"
             #
-            #   # v0.4.x or earlier
+            #   # v0.13.x or earlier
             #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel(bigint, int, bigint)"
             #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.handle_feistel_encryption()"
           end

--- a/lib/upgrade.ex
+++ b/lib/upgrade.ex
@@ -1,0 +1,157 @@
+defmodule Mix.Tasks.FeistelCipher.Upgrade.Docs do
+  @moduledoc false
+
+  def short_doc do
+    "Generate a migration to upgrade FeistelCipher from v0.x to v1.0"
+  end
+
+  def example do
+    "mix feistel_cipher.upgrade"
+  end
+
+  def long_doc do
+    """
+    #{short_doc()}
+
+    Generates an Ecto migration that upgrades your database from FeistelCipher v0.x to v1.0.
+
+    v1.0 uses new PostgreSQL functions (`feistel_cipher_v1`, `feistel_column_trigger_v1`)
+    that coexist with the old ones, allowing a smooth upgrade.
+
+    ## Example
+
+    ```bash
+    #{example()}
+    ```
+
+    ## Options
+
+    * `--repo` or `-r` — Specify an Ecto repo for FeistelCipher to use.
+    * `--functions-prefix` or `-p` — Specify the PostgreSQL schema prefix (default: `public`)
+    """
+  end
+end
+
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.FeistelCipher.Upgrade do
+    @shortdoc __MODULE__.Docs.short_doc()
+    @moduledoc __MODULE__.Docs.long_doc()
+
+    use Igniter.Mix.Task
+
+    @impl Igniter.Mix.Task
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :feistel_cipher,
+        adds_deps: [],
+        installs: [],
+        example: __MODULE__.Docs.example(),
+        only: nil,
+        positional: [],
+        composes: [],
+        schema: [repo: :string, functions_prefix: :string],
+        defaults: [functions_prefix: "public"],
+        aliases: [r: :repo, p: :functions_prefix],
+        required: []
+      }
+    end
+
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      app_name = Igniter.Project.Application.app_name(igniter)
+      opts = igniter.args.options
+
+      case extract_repo(igniter, app_name, opts[:repo]) do
+        {:ok, repo} ->
+          functions_prefix = opts[:functions_prefix]
+
+          migration = """
+          def up do
+            # === Step 1: Install v1 functions ===
+            # These coexist with the old v0.x functions (feistel_cipher, feistel_column_trigger).
+            # Use the SAME functions_salt from your original feistel_cipher.install migration.
+            # Find it in the migration file with timestamp 19730501000000.
+            FeistelCipher.up_for_functions(functions_prefix: "#{functions_prefix}", functions_salt: :REPLACE_WITH_YOUR_SALT)
+
+            # === Step 2: Upgrade each trigger from v0.x to v1 ===
+            # For each table using Feistel cipher, drop the old trigger and create a new one.
+            # Find your triggers in previous migrations where up_for_trigger was called.
+            #
+            # Upgrade guide:
+            #   bits: N  →  time_bits: 0, data_bits: N
+            #   (if bits was not specified, the old default was 52)
+            #
+            # Example:
+            #   execute FeistelCipher.force_down_for_trigger("#{functions_prefix}", "posts", "seq", "id")
+            #   execute FeistelCipher.up_for_trigger("#{functions_prefix}", "posts", "seq", "id",
+            #     time_bits: 0, data_bits: 52, functions_prefix: "#{functions_prefix}")
+
+            # === Step 3 (optional): Drop old v0.x functions ===
+            # After all triggers are upgraded, you can remove the old functions:
+            #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel_cipher(bigint, int, bigint, int)"
+            #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel_column_trigger()"
+          end
+
+          def down do
+            raise "Irreversible migration"
+          end
+          """
+
+          igniter
+          |> Igniter.Libs.Ecto.gen_migration(repo, "upgrade_feistel_cipher_to_v1",
+            body: migration,
+            on_exists: :skip
+          )
+
+        {:error, igniter} ->
+          igniter
+      end
+    end
+
+    defp extract_repo(igniter, app_name, nil) do
+      case Igniter.Libs.Ecto.list_repos(igniter) do
+        {_igniter, [repo | _]} ->
+          {:ok, repo}
+
+        _ ->
+          issue = """
+          No ecto repos found for #{inspect(app_name)}.
+
+          Ensure `:ecto` is installed and configured for the current application.
+          """
+
+          {:error, Igniter.add_issue(igniter, issue)}
+      end
+    end
+
+    defp extract_repo(igniter, _app_name, module) do
+      repo = Igniter.Project.Module.parse(module)
+
+      case Igniter.Project.Module.module_exists(igniter, repo) do
+        {true, _igniter} ->
+          {:ok, repo}
+
+        {false, _} ->
+          {:error, Igniter.add_issue(igniter, "Provided repo (#{inspect(repo)}) doesn't exist")}
+      end
+    end
+  end
+else
+  defmodule Mix.Tasks.FeistelCipher.Upgrade do
+    @shortdoc "#{__MODULE__.Docs.short_doc()} | Install `igniter` to use"
+
+    @moduledoc __MODULE__.Docs.long_doc()
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'feistel_cipher.upgrade' requires igniter. Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter/readme.html#installation
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/upgrade.ex
+++ b/lib/upgrade.ex
@@ -87,9 +87,20 @@ if Code.ensure_loaded?(Igniter) do
             #     time_bits: 0, data_bits: 52, functions_prefix: "#{functions_prefix}")
 
             # === Step 3 (optional): Drop old v0.x functions ===
-            # After all triggers are upgraded, you can remove the old functions:
+            # After all triggers are upgraded, you can remove the old functions.
+            # Which functions exist depends on which version you're upgrading from:
+            #
+            #   # v0.15.0
             #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel_cipher(bigint, int, bigint, int)"
             #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel_column_trigger()"
+            #
+            #   # v0.14.0
+            #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel_encrypt(bigint, int, bigint, int)"
+            #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel_column_trigger()"
+            #
+            #   # v0.4.x or earlier
+            #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.feistel(bigint, int, bigint)"
+            #   execute "DROP FUNCTION IF EXISTS #{functions_prefix}.handle_feistel_encryption()"
           end
 
           def down do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FeistelCipher.MixProject do
   def project do
     [
       app: :feistel_cipher,
-      version: "0.16.0",
+      version: "1.0.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       consolidate_protocols: Mix.env() not in [:dev, :test],

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,7 @@ defmodule FeistelCipher.MixProject do
       links: %{
         "GitHub" => "https://github.com/devall-org/feistel_cipher"
       },
-      files: ~w(lib mix.exs README.md LICENSE assets)
+      files: ~w(lib mix.exs README.md UPGRADE.md LICENSE assets)
     ]
   end
 end

--- a/test/ecto_integration_test.exs
+++ b/test/ecto_integration_test.exs
@@ -101,7 +101,7 @@ defmodule FeistelCipher.EctoIntegrationTest do
 
       %{rows: [[decrypted_seq]]} =
         TestRepo.query!(
-          "SELECT public.feistel_cipher($1::bigint, $2, $3::bigint, 16)",
+          "SELECT public.feistel_cipher_v1($1::bigint, $2, $3::bigint, 16)",
           [data_component, data_bits, key]
         )
 
@@ -110,7 +110,7 @@ defmodule FeistelCipher.EctoIntegrationTest do
       # Verify determinism: encrypting seq gives the same data_component
       %{rows: [[db_data_component]]} =
         TestRepo.query!(
-          "SELECT public.feistel_cipher($1::bigint, $2, $3::bigint, 16)",
+          "SELECT public.feistel_cipher_v1($1::bigint, $2, $3::bigint, 16)",
           [seq, data_bits, key]
         )
 
@@ -125,17 +125,16 @@ defmodule FeistelCipher.EctoIntegrationTest do
       assert post.id != post.seq
       assert post.title == "Hello"
 
-      # Default: time_bits: 12, time_offset: 0, time_bucket: 86400, data_bits: 40
+      # Default: time_bits: 12, time_bucket: 86400, data_bits: 40
       time_bits = 12
       data_bits = 40
-      time_offset = 0
       time_bucket = 86400
 
       epoch_now = System.os_time(:second)
       time_mask = Bitwise.bsl(1, time_bits) - 1
 
       expected_time_prefix =
-        div(epoch_now - time_offset, time_bucket) |> Bitwise.band(time_mask)
+        div(epoch_now, time_bucket) |> Bitwise.band(time_mask)
 
       actual_time_prefix = Bitwise.bsr(post.id, data_bits)
       assert actual_time_prefix == expected_time_prefix


### PR DESCRIPTION
## Summary

- PG functions renamed with `_v1` suffix (`feistel_cipher_v1`, `feistel_column_trigger_v1`) to coexist with old functions during upgrade
- `bits` option renamed to `data_bits` (default: 40), new `time_bits` option (default: 12) for time-based prefix
- `time_offset` option removed entirely
- `mix feistel_cipher.upgrade` task for smooth v0.x → v1.0 migration

## Test plan

- [x] All 45 existing tests pass (golden tests, reversibility, trigger tests)
- [ ] Manual test: `mix feistel_cipher.upgrade` on a sample project
- [ ] Verify upgrade path: v0.15.0 triggers work alongside v1 functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)