### PR TITLE
Change default time_bucket from 86400 to 3600

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ With a time prefix, rows from the same time bucket land on nearby pages, so incr
 Use a time prefix when you want write locality and smaller incremental backups on large/high-write tables.
 
 - Example: `events`, `logs`, `orders`, `messages` tables that receive continuous inserts.
-- Typical config: `time_bits: 12`, `time_bucket: 86400` (daily) or `3600` (hourly for tighter locality windows).
+- Typical config: `time_bits: 12`, `time_bucket: 3600` (hourly, default) or `86400` (daily for wider locality windows).
 
 ### When NOT to Use Time Prefix (`time_bits: 0`)
 
@@ -170,8 +170,8 @@ The `up_for_trigger/5` function accepts these options:
 
 - `prefix`, `table`, `from`, `to`: Table and column names (required)
 - `time_bits`: Time prefix bits (default: 12). Set to 0 for no time prefix
-- `time_bucket`: Time bucket size in seconds (default: `86400`)
-  - Example: `3600` for 1 hour, `86400` for 1 day
+- `time_bucket`: Time bucket size in seconds (default: `3600`)
+  - Example: `3600` for 1 hour (default), `86400` for 1 day
   - Rows inserted within the same bucket share the same time prefix
 - `encrypt_time`: Whether to encrypt the time prefix with Feistel cipher (default: `false`)
   - `false`: Time prefix may reflect recent bucket progression, but it is **not** a globally orderable timestamp

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,7 @@ v0.14.0/v0.15.0 → v1.0.0 is **fully backward compatible** when using `time_bit
 - **`bits` option renamed to `data_bits`** (default changed from 52 to 40)
 - **New `time_bits` option** (default: 12) for time-based prefix. Use `time_bits: 0` to keep the old behavior.
 - **`time_offset` option removed**
-- **New options**: `time_bucket` (default: 86400), `encrypt_time` (default: false)
+- **New options**: `time_bucket` (default: 3600), `encrypt_time` (default: false)
 
 ### Steps
 

--- a/lib/feistel_cipher.ex
+++ b/lib/feistel_cipher.ex
@@ -260,7 +260,7 @@ defmodule FeistelCipher do
   ## Options
 
   * `:time_bits` - Time prefix bits (default: 12). Set to 0 for no time prefix. ⚠️ Cannot be changed after creation.
-  * `:time_bucket` - Time bucket size in seconds (default: 86400 = 1 day). ⚠️ Cannot be changed after creation.
+  * `:time_bucket` - Time bucket size in seconds (default: 3600 = 1 hour). ⚠️ Cannot be changed after creation.
   * `:encrypt_time` - Whether to encrypt time_bits with feistel cipher (default: false). When true, time_bits must be even. ⚠️ Cannot be changed after creation.
   * `:data_bits` - Data cipher bits (default: 40, must be even). ⚠️ Cannot be changed after creation.
   * `:key` - Encryption key (0 to 2^31-1). Auto-generated if not provided. ⚠️ Cannot be changed after creation.
@@ -312,7 +312,7 @@ defmodule FeistelCipher do
       end
     end
 
-    time_bucket = Keyword.get(opts, :time_bucket, 86400)
+    time_bucket = Keyword.get(opts, :time_bucket, 3600)
 
     unless time_bucket > 0 do
       raise ArgumentError, "time_bucket must be positive, got: #{time_bucket}"

--- a/test/ecto_integration_test.exs
+++ b/test/ecto_integration_test.exs
@@ -125,10 +125,10 @@ defmodule FeistelCipher.EctoIntegrationTest do
       assert post.id != post.seq
       assert post.title == "Hello"
 
-      # Default: time_bits: 12, time_bucket: 86400, data_bits: 40
+      # Default: time_bits: 12, time_bucket: 3600, data_bits: 40
       time_bits = 12
       data_bits = 40
-      time_bucket = 86400
+      time_bucket = 3600
 
       epoch_now = System.os_time(:second)
       time_mask = Bitwise.bsl(1, time_bits) - 1

--- a/test/feistel_cipher_test.exs
+++ b/test/feistel_cipher_test.exs
@@ -882,10 +882,10 @@ defmodule FeistelCipher.MigrationTest do
       assert sql =~ "40"
       assert sql =~ "'seq'"
       assert sql =~ "'id'"
-      # default time_bits: 12, time_bucket: 86400
+      # default time_bits: 12, time_bucket: 3600
       # trigger params: from, to, time_bits, time_bucket, encrypt_time, data_bits, key, rounds
       assert sql =~ "12"
-      assert sql =~ "86400"
+      assert sql =~ "3600"
     end
 
     test "uses custom data_bits" do


### PR DESCRIPTION
## Summary
- Change default `time_bucket` from 86400 (1 day) to 3600 (1 hour)
- Hourly buckets cycle through time prefix space faster (~170 days with 12 time_bits), making better use of ID number space
- Updated lib, docs, and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)