### PR TITLE
Change default bits to time_bits 14 and data_bits 38

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,8 +7,8 @@ v0.14.0/v0.15.0 → v1.0.0 is **fully backward compatible** when using `time_bit
 ### What changed
 
 - **PG function names**: `feistel_cipher` → `feistel_cipher_v1`, `feistel_column_trigger` → `feistel_trigger_v1`. Old functions are left untouched so they coexist during upgrade.
-- **`bits` option renamed to `data_bits`** (default changed from 52 to 40)
-- **New `time_bits` option** (default: 12) for time-based prefix. Use `time_bits: 0` to keep the old behavior.
+- **`bits` option renamed to `data_bits`** (default changed from 52 to 38)
+- **New `time_bits` option** (default: 14) for time-based prefix. Use `time_bits: 0` to keep the old behavior.
 - **`time_offset` option removed**
 - **New options**: `time_bucket` (default: 86400), `encrypt_time` (default: false)
 

--- a/lib/feistel_cipher.ex
+++ b/lib/feistel_cipher.ex
@@ -256,101 +256,39 @@ defmodule FeistelCipher do
   Use this in old migrations that previously called `FeistelCipher.Migration.up/1`
   so that `mix ecto.migrate` works from scratch with feistel_cipher v1.0.
 
+  The created legacy functions are compatibility stubs that raise if called.
+  They exist only so historical migrations can run.
+
   Uses `CREATE OR REPLACE` for idempotency.
 
   ## Options
 
   * `:functions_prefix` - Schema prefix (default: "public").
-  * `:functions_salt` - Salt value for the cipher (required). This was the `seed` in v0.x.
+  * `:functions_salt` - Required for backward compatibility with old migrations (unused by stubs).
   """
   @spec up_for_legacy_functions(keyword()) :: :ok
   def up_for_legacy_functions(opts \\ []) when is_list(opts) do
     functions_prefix = Keyword.get(opts, :functions_prefix, "public")
-    functions_salt = Keyword.fetch!(opts, :functions_salt)
+    _functions_salt = Keyword.fetch!(opts, :functions_salt)
 
     execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
 
     execute("""
     CREATE OR REPLACE FUNCTION #{functions_prefix}.feistel(input bigint, bits int, key bigint) returns bigint AS $$
-      DECLARE
-        i          int;
-        left_half  bigint;
-        right_half bigint;
-        temp       bigint;
-        half_bits  int    := bits / 2;
-        half_mask  bigint := (1::bigint << half_bits) - 1;
-        mask       bigint := (1::bigint << bits) - 1;
-        hash_bytes bytea;
-        hash_int   bigint;
       BEGIN
-        IF bits < 2 OR bits > 62 OR bits % 2 = 1 THEN
-          RAISE EXCEPTION 'feistel bits must be an even number between 2 and 62: %', bits;
-        END IF;
-        IF key < 0 OR key >= (1::bigint << 31) THEN
-          RAISE EXCEPTION 'feistel key must be between 0 and 2^31-1: %', key;
-        END IF;
-        IF input < 0 OR input > mask THEN
-          RAISE EXCEPTION 'feistel input must be between 0 and % for % bits: %', mask, bits, input;
-        END IF;
-        left_half  := (input >> half_bits) & half_mask;
-        right_half := input & half_mask;
-        FOR i IN 1..16 LOOP
-          temp       := right_half;
-          hash_bytes := hmac(int4send(right_half::int4), int4send(key::int4) || int4send(#{functions_salt}::int4), 'sha256');
-          hash_int   := get_byte(hash_bytes, 0)::bigint << 24
-                      | get_byte(hash_bytes, 1)::bigint << 16
-                      | get_byte(hash_bytes, 2)::bigint << 8
-                      | get_byte(hash_bytes, 3)::bigint;
-          right_half := left_half # (hash_int & half_mask);
-          left_half  := temp;
-        END LOOP;
-        temp       := left_half;
-        left_half  := right_half;
-        right_half := temp;
-        RETURN ((left_half << half_bits) | right_half);
+        RAISE EXCEPTION
+          'legacy function %.feistel(bigint, int, bigint) is compatibility-only and must not be called; migrate triggers to feistel_trigger_v1',
+          #{inspect(functions_prefix)};
       END;
     $$ LANGUAGE plpgsql strict immutable;
     """)
 
     execute("""
     CREATE OR REPLACE FUNCTION #{functions_prefix}.handle_feistel_encryption() RETURNS trigger AS $$
-      DECLARE
-        bits int;
-        key bigint;
-        clear_column text;
-        encrypted_column text;
-        old_clear bigint;
-        new_clear bigint;
-        encrypted bigint;
-        decrypted bigint;
       BEGIN
-        bits             := TG_ARGV[0]::int;
-        key              := TG_ARGV[1]::bigint;
-        clear_column     := TG_ARGV[2];
-        encrypted_column := TG_ARGV[3];
-        IF TG_OP = 'UPDATE' THEN
-          EXECUTE format('SELECT ($1).%I::bigint, ($2).%I::bigint', clear_column, clear_column)
-          INTO old_clear, new_clear
-          USING OLD, NEW;
-          IF NOT (old_clear IS DISTINCT FROM new_clear) THEN
-            RETURN NEW;
-          END IF;
-        ELSE
-          EXECUTE format('SELECT ($1).%I::bigint', clear_column)
-          INTO new_clear
-          USING NEW;
-        END IF;
-        IF new_clear IS NULL THEN
-          encrypted := NULL;
-        ELSE
-          encrypted := #{functions_prefix}.feistel(new_clear, bits, key);
-          decrypted := #{functions_prefix}.feistel(encrypted, bits, key);
-          IF decrypted IS DISTINCT FROM new_clear THEN
-            RAISE EXCEPTION 'feistel function does not have an inverse. clear: %, encrypted: %, decrypted: %, bits: %, key: %',
-              new_clear, encrypted, decrypted, bits, key;
-          END IF;
-        END IF;
-        NEW := jsonb_populate_record(NEW, jsonb_build_object(encrypted_column, to_jsonb(encrypted)));
+        RAISE EXCEPTION
+          'legacy trigger function %.handle_feistel_encryption() is compatibility-only and must not be called; migrate triggers to feistel_trigger_v1',
+          #{inspect(functions_prefix)};
         RETURN NEW;
       END;
     $$ LANGUAGE plpgsql;

--- a/test/ecto_integration_test.exs
+++ b/test/ecto_integration_test.exs
@@ -91,8 +91,8 @@ defmodule FeistelCipher.EctoIntegrationTest do
       seq = post.seq
       encrypted_id = post.id
 
-      # With time_bits: 12 (default), data_bits: 40 (default)
-      data_bits = 40
+      # With time_bits: 14 (default), data_bits: 38 (default)
+      data_bits = 38
       data_mask = Bitwise.bsl(1, data_bits) - 1
       data_component = Bitwise.band(encrypted_id, data_mask)
 
@@ -125,9 +125,9 @@ defmodule FeistelCipher.EctoIntegrationTest do
       assert post.id != post.seq
       assert post.title == "Hello"
 
-      # Default: time_bits: 12, time_bucket: 86400, data_bits: 40
-      time_bits = 12
-      data_bits = 40
+      # Default: time_bits: 14, time_bucket: 86400, data_bits: 38
+      time_bits = 14
+      data_bits = 38
       time_bucket = 86400
 
       epoch_now = System.os_time(:second)

--- a/test/feistel_cipher_test.exs
+++ b/test/feistel_cipher_test.exs
@@ -412,7 +412,7 @@ defmodule FeistelCipher.MigrationTest do
       key = FeistelCipher.generate_key("public", "test_posts", "seq", "id")
 
       decrypted =
-        TestRepo.query!("SELECT public.feistel_cipher_v1($1, 40, $2, 16)", [id, key])
+        TestRepo.query!("SELECT public.feistel_cipher_v1($1, 38, $2, 16)", [id, key])
 
       [[actual]] = decrypted.rows
       assert actual == seq
@@ -431,7 +431,7 @@ defmodule FeistelCipher.MigrationTest do
 
       for [seq, id] <- result.rows do
         decrypted =
-          TestRepo.query!("SELECT public.feistel_cipher_v1($1, 40, $2, 16)", [id, key])
+          TestRepo.query!("SELECT public.feistel_cipher_v1($1, 38, $2, 16)", [id, key])
 
         [[actual]] = decrypted.rows
         assert actual == seq
@@ -458,7 +458,7 @@ defmodule FeistelCipher.MigrationTest do
       key = FeistelCipher.generate_key("public", "test_posts", "seq", "id")
 
       decrypted =
-        TestRepo.query!("SELECT public.feistel_cipher_v1($1, 40, $2, 16)", [
+        TestRepo.query!("SELECT public.feistel_cipher_v1($1, 38, $2, 16)", [
           original_id,
           key
         ])
@@ -489,7 +489,7 @@ defmodule FeistelCipher.MigrationTest do
       key = FeistelCipher.generate_key("public", "test_posts", "seq", "id")
 
       decrypted =
-        TestRepo.query!("SELECT public.feistel_cipher_v1($1, 40, $2, 16)", [
+        TestRepo.query!("SELECT public.feistel_cipher_v1($1, 38, $2, 16)", [
           new_id,
           key
         ])
@@ -573,7 +573,7 @@ defmodule FeistelCipher.MigrationTest do
 
       # Verify id is encrypted version of seq (data_bits default: 38)
       decrypted =
-        TestRepo.query!("SELECT public.feistel_cipher_v1($1, 40, $2, 16)", [id, key])
+        TestRepo.query!("SELECT public.feistel_cipher_v1($1, 38, $2, 16)", [id, key])
 
       [[decrypted_seq]] = decrypted.rows
       assert decrypted_seq == 42
@@ -1039,7 +1039,7 @@ defmodule FeistelCipher.MigrationTest do
         FeistelCipher.up_for_legacy_trigger("public", "users", "seq", "id", encrypt_time: true)
 
       # encrypt_time = true (5th arg: from, to, time_bits, time_bucket, encrypt_time, data_bits, key, rounds)
-      assert sql =~ ", true, 40,"
+      assert sql =~ ", true, 38,"
     end
   end
 

--- a/test/feistel_cipher_test.exs
+++ b/test/feistel_cipher_test.exs
@@ -408,7 +408,7 @@ defmodule FeistelCipher.MigrationTest do
       assert is_integer(seq)
       assert is_integer(id)
 
-      # Verify id is encrypted version of seq (data_bits default: 40)
+      # Verify id is encrypted version of seq (data_bits default: 38)
       key = FeistelCipher.generate_key("public", "test_posts", "seq", "id")
 
       decrypted =
@@ -426,7 +426,7 @@ defmodule FeistelCipher.MigrationTest do
       result = TestRepo.query!("SELECT seq, id FROM test_posts ORDER BY seq")
       assert length(result.rows) == 5
 
-      # Verify all are encrypted correctly (data_bits default: 40)
+      # Verify all are encrypted correctly (data_bits default: 38)
       key = FeistelCipher.generate_key("public", "test_posts", "seq", "id")
 
       for [seq, id] <- result.rows do
@@ -571,7 +571,7 @@ defmodule FeistelCipher.MigrationTest do
       # Calculate the key for this specific table
       key = FeistelCipher.generate_key("public", "test_nullable_update", "seq", "id")
 
-      # Verify id is encrypted version of seq (data_bits default: 40)
+      # Verify id is encrypted version of seq (data_bits default: 38)
       decrypted =
         TestRepo.query!("SELECT public.feistel_cipher_v1($1, 40, $2, 16)", [id, key])
 
@@ -882,13 +882,13 @@ defmodule FeistelCipher.MigrationTest do
       refute sql =~ "users_encrypt_seq_to_id_v1_trigger"
       assert sql =~ "public.users"
       assert sql =~ "feistel_trigger_v1"
-      # default data_bits: 40
-      assert sql =~ "40"
+      # default data_bits: 38
+      assert sql =~ "38"
       assert sql =~ "'seq'"
       assert sql =~ "'id'"
-      # default time_bits: 12, time_bucket: 86400
+      # default time_bits: 14, time_bucket: 86400
       # trigger params: from, to, time_bits, time_bucket, encrypt_time, data_bits, key, rounds
-      assert sql =~ "12"
+      assert sql =~ "14"
       assert sql =~ "86400"
     end
 


### PR DESCRIPTION
## Summary
- change trigger defaults to `time_bits: 14`, `time_bucket: 86400`, and `data_bits: 38`
- update docs and upgrade notes to match the new defaults and explain the ~44 years 10 months wrap period when `encrypt_time: false`
- tighten function input validation to reject negative values in feistel SQL functions