### PR TITLE
Add time_offset to align daily time buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The `up_for_trigger/5` function accepts these options:
   - Rows inserted within the same bucket share the same time prefix
 - `time_offset`: Time offset in seconds applied before bucket calculation (default: `0`)
   - Formula: `time_value = floor((epoch + time_offset) / time_bucket)`
+  - Sign convention: positive values move the boundary earlier in local time; negative values move it later
   - Example: `time_bucket: 86400`, `time_offset: 21600` shifts daily boundary from `00:00 UTC` to `18:00 UTC` (`03:00 KST`)
   - Use this when business day boundaries differ from UTC midnight, or when multiple countries need a stable operational cutover time
 - `encrypt_time`: Whether to encrypt the time prefix with Feistel cipher (default: `false`)
@@ -204,6 +205,8 @@ The `up_for_trigger/5` function accepts these options:
 `time_bucket` alone uses UTC-based boundaries. For daily buckets, that means bucket changes at UTC midnight, which may split a local business day at an awkward hour (for example, 09:00 in Korea, or even earlier/later in other regions).
 
 `time_offset` lets you align bucket boundaries to your operational day (for example, 03:00 local cutover) without changing `time_bucket` size. This improves practical continuity for time-prefix clustering, especially when `encrypt_time: true` is enabled and the prefix itself is not human-readable.
+
+In this library, `time_offset` is added to epoch before bucketing. That is why `+21600` (not `-21600`) gives a 03:00 KST boundary for daily buckets.
 
 Example with custom options:
 ```elixir

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ The `up_for_trigger/5` function accepts these options:
 - `time_bucket`: Time bucket size in seconds (default: `86400`)
   - Example: `86400` for 1 day (default), `3600` for 1 hour
   - Rows inserted within the same bucket share the same time prefix
+- `time_offset`: Time offset in seconds applied before bucket calculation (default: `0`)
+  - Formula: `time_value = floor((epoch + time_offset) / time_bucket)`
+  - Example: `time_bucket: 86400`, `time_offset: 21600` shifts daily boundary from `00:00 UTC` to `18:00 UTC` (`03:00 KST`)
+  - Use this when business day boundaries differ from UTC midnight, or when multiple countries need a stable operational cutover time
 - `encrypt_time`: Whether to encrypt the time prefix with Feistel cipher (default: `false`)
   - `false`: Time prefix may reflect recent bucket progression, but it is **not** a globally orderable timestamp
   - `true`: Time prefix is encrypted (hides time patterns, but same-bucket rows still share prefix). `time_bits` must be even
@@ -195,12 +199,19 @@ The `up_for_trigger/5` function accepts these options:
 
 > ⚠️ You cannot reliably compare IDs by `time_bits` alone to determine temporal order. Because `time_value = floor(now / time_bucket) mod 2^time_bits`, the prefix wraps after `time_bucket * 2^time_bits` seconds. This feature is intended to improve PostgreSQL incremental backup locality, not to provide UUIDv7-style global time ordering.
 
+### Why `time_offset` Exists
+
+`time_bucket` alone uses UTC-based boundaries. For daily buckets, that means bucket changes at UTC midnight, which may split a local business day at an awkward hour (for example, 09:00 in Korea, or even earlier/later in other regions).
+
+`time_offset` lets you align bucket boundaries to your operational day (for example, 03:00 local cutover) without changing `time_bucket` size. This improves practical continuity for time-prefix clustering, especially when `encrypt_time: true` is enabled and the prefix itself is not human-readable.
+
 Example with custom options:
 ```elixir
 execute FeistelCipher.up_for_trigger(
   "public", "posts", "seq", "id",
   time_bits: 8,
   time_bucket: 86400,
+  time_offset: 21600,
   data_bits: 32,
   key: 123456789,
   rounds: 8,

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The `up_for_trigger/5` function accepts these options:
 
 ### Why `time_offset` Exists
 
-`time_bucket` alone uses UTC-based boundaries. For daily buckets, that means bucket changes at UTC midnight, which may split a local business day at an awkward hour (for example, 09:00 in Korea, or even earlier/later in other regions).
+`time_bucket` alone uses UTC-based boundaries. For daily buckets, that means bucket changes at UTC midnight, which may split a local business day at awkward local times (for example, evening in the Americas or early morning in Europe).
 
 `time_offset` lets you align bucket boundaries to your operational day (for example, 03:00 local cutover) without changing `time_bucket` size. This improves practical continuity for time-prefix clustering, especially when `encrypt_time: true` is enabled and the prefix itself is not human-readable.
 


### PR DESCRIPTION
## Summary
- add configurable time_offset option to trigger generation and runtime validation
- apply time_offset to bucket calculation so day boundaries can align to business cutover time
- document why time_offset is needed and add tests for SQL args and time-prefix behavior