### PR TITLE
Fix time_bits=0 handling and replace down_for_trigger SQL safety guard with Elixir exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The `up_for_trigger/5` function accepts these options:
   - Rows inserted within the same bucket share the same time prefix
 - `time_offset`: Time offset in seconds applied before bucket calculation (default: `0`)
   - Formula: `time_value = floor((epoch + time_offset) / time_bucket)`
+  - Sign convention: positive values move the boundary earlier in local time; negative values move it later
   - Example: `time_bucket: 86400`, `time_offset: 21600` shifts daily boundary from `00:00 UTC` to `18:00 UTC` (`03:00 KST`)
   - Use this when business day boundaries differ from UTC midnight, or when multiple countries need a stable operational cutover time
 - `encrypt_time`: Whether to encrypt the time prefix with Feistel cipher (default: `false`)
@@ -204,6 +205,8 @@ The `up_for_trigger/5` function accepts these options:
 `time_bucket` alone uses UTC-based boundaries. For daily buckets, that means bucket changes at UTC midnight, which may split a local business day at an awkward hour (for example, 09:00 in Korea, or even earlier/later in other regions).
 
 `time_offset` lets you align bucket boundaries to your operational day (for example, 03:00 local cutover) without changing `time_bucket` size. This improves practical continuity for time-prefix clustering, especially when `encrypt_time: true` is enabled and the prefix itself is not human-readable.
+
+In this library, `time_offset` is added to epoch before bucketing. That is why `+21600` (not `-21600`) gives a 03:00 KST boundary for daily buckets.
 
 Example with custom options:
 ```elixir

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ The `up_for_trigger/5` function accepts these options:
 - `time_bucket`: Time bucket size in seconds (default: `86400`)
   - Example: `86400` for 1 day (default), `3600` for 1 hour
   - Rows inserted within the same bucket share the same time prefix
+- `time_offset`: Time offset in seconds applied before bucket calculation (default: `0`)
+  - Formula: `time_value = floor((epoch + time_offset) / time_bucket)`
+  - Example: `time_bucket: 86400`, `time_offset: 21600` shifts daily boundary from `00:00 UTC` to `18:00 UTC` (`03:00 KST`)
+  - Use this when business day boundaries differ from UTC midnight, or when multiple countries need a stable operational cutover time
 - `encrypt_time`: Whether to encrypt the time prefix with Feistel cipher (default: `false`)
   - `false`: Time prefix may reflect recent bucket progression, but it is **not** a globally orderable timestamp
   - `true`: Time prefix is encrypted (hides time patterns, but same-bucket rows still share prefix). `time_bits` must be even
@@ -195,12 +199,19 @@ The `up_for_trigger/5` function accepts these options:
 
 > ⚠️ You cannot reliably compare IDs by `time_bits` alone to determine temporal order. Because `time_value = floor(now / time_bucket) mod 2^time_bits`, the prefix wraps after `time_bucket * 2^time_bits` seconds. This feature is intended to improve PostgreSQL incremental backup locality, not to provide UUIDv7-style global time ordering.
 
+### Why `time_offset` Exists
+
+`time_bucket` alone uses UTC-based boundaries. For daily buckets, that means bucket changes at UTC midnight, which may split a local business day at an awkward hour (for example, 09:00 in Korea, or even earlier/later in other regions).
+
+`time_offset` lets you align bucket boundaries to your operational day (for example, 03:00 local cutover) without changing `time_bucket` size. This improves practical continuity for time-prefix clustering, especially when `encrypt_time: true` is enabled and the prefix itself is not human-readable.
+
 Example with custom options:
 ```elixir
 execute FeistelCipher.up_for_trigger(
   "public", "posts", "seq", "id",
   time_bits: 8,
   time_bucket: 86400,
+  time_offset: 21600,
   data_bits: 32,
   key: 123456789,
   rounds: 8,

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The `up_for_trigger/5` function accepts these options:
 
 ### Why `time_offset` Exists
 
-`time_bucket` alone uses UTC-based boundaries. For daily buckets, that means bucket changes at UTC midnight, which may split a local business day at an awkward hour (for example, 09:00 in Korea, or even earlier/later in other regions).
+`time_bucket` alone uses UTC-based boundaries. For daily buckets, that means bucket changes at UTC midnight, which may split a local business day at awkward local times (for example, evening in the Americas or early morning in Europe).
 
 `time_offset` lets you align bucket boundaries to your operational day (for example, 03:00 local cutover) without changing `time_bucket` size. This improves practical continuity for time-prefix clustering, especially when `encrypt_time: true` is enabled and the prefix itself is not human-readable.
 

--- a/lib/feistel_cipher.ex
+++ b/lib/feistel_cipher.ex
@@ -375,16 +375,19 @@ defmodule FeistelCipher do
       end
     end
 
-    time_bucket = if use_time_prefix, do: Keyword.get(opts, :time_bucket, 86400), else: nil
-    time_offset = if use_time_prefix, do: Keyword.get(opts, :time_offset, 0), else: nil
+    effective_time_bucket =
+      if use_time_prefix, do: Keyword.get(opts, :time_bucket, 86400), else: 0
+
+    effective_time_offset = if use_time_prefix, do: Keyword.get(opts, :time_offset, 0), else: 0
 
     if use_time_prefix do
-      unless time_bucket > 0 do
-        raise ArgumentError, "time_bucket must be positive, got: #{time_bucket}"
+      unless effective_time_bucket > 0 do
+        raise ArgumentError, "time_bucket must be positive, got: #{effective_time_bucket}"
       end
 
-      unless is_integer(time_offset) do
-        raise ArgumentError, "time_offset must be an integer, got: #{inspect(time_offset)}"
+      unless is_integer(effective_time_offset) do
+        raise ArgumentError,
+              "time_offset must be an integer, got: #{inspect(effective_time_offset)}"
       end
     end
 
@@ -421,7 +424,7 @@ defmodule FeistelCipher do
       BEFORE INSERT OR UPDATE
       ON #{prefix}.#{table}
       FOR EACH ROW
-      EXECUTE PROCEDURE #{functions_prefix}.feistel_trigger_v1('#{from}', '#{to}', #{time_bits}, #{time_bucket || 0}, #{time_offset || 0}, #{effective_encrypt_time}, #{data_bits}, #{key}, #{rounds});
+      EXECUTE PROCEDURE #{functions_prefix}.feistel_trigger_v1('#{from}', '#{to}', #{time_bits}, #{effective_time_bucket}, #{effective_time_offset}, #{effective_encrypt_time}, #{data_bits}, #{key}, #{rounds});
     """
   end
 

--- a/lib/feistel_cipher.ex
+++ b/lib/feistel_cipher.ex
@@ -168,17 +168,6 @@ defmodule FeistelCipher do
         key          := TG_ARGV[7]::bigint;
         rounds       := TG_ARGV[8]::int;
 
-        -- Fail fast on malformed trigger arguments instead of silently defaulting.
-        -- time_bucket and time_offset are only required when time_bits > 0.
-        IF from_column IS NULL OR to_column IS NULL OR
-           time_bits IS NULL OR
-           (time_bits > 0 AND (time_bucket IS NULL OR time_offset IS NULL)) OR
-           encrypt_time IS NULL OR data_bits IS NULL OR key IS NULL OR rounds IS NULL THEN
-          RAISE EXCEPTION
-            'feistel_trigger_v1 misconfigured: expected 9 non-null trigger arguments, got TG_ARGV=%',
-            TG_ARGV;
-        END IF;
-
         -- Early return: If from_column is not modified on UPDATE, skip re-encryption.
         -- This allows manual modification of to_column if from_column remains unchanged.
         IF TG_OP = 'UPDATE' THEN

--- a/test/feistel_cipher_test.exs
+++ b/test/feistel_cipher_test.exs
@@ -1017,16 +1017,37 @@ defmodule FeistelCipher.MigrationTest do
                    end
     end
 
-    test "raises when encrypt_time: true and time_bits < 2" do
-      assert_raise ArgumentError,
-                   ~r/time_bits must be >= 2 when encrypt_time is true/,
-                   fn ->
-                     FeistelCipher.up_for_legacy_trigger("public", "users", "seq", "id",
-                       time_bits: 0,
-                       encrypt_time: true,
-                       data_bits: 40
-                     )
-                   end
+    test "ignores encrypt_time when time_bits is 0" do
+      sql =
+        FeistelCipher.up_for_legacy_trigger("public", "users", "seq", "id",
+          time_bits: 0,
+          encrypt_time: true,
+          data_bits: 40
+        )
+
+      assert sql =~ ", 0, false, 40,"
+    end
+
+    test "skips time_bucket validation when time_bits is 0" do
+      sql =
+        FeistelCipher.up_for_legacy_trigger("public", "users", "seq", "id",
+          time_bits: 0,
+          time_bucket: 0,
+          data_bits: 40
+        )
+
+      assert sql =~ ", 0, 0, 0, false, 40,"
+    end
+
+    test "skips time_offset validation when time_bits is 0" do
+      sql =
+        FeistelCipher.up_for_legacy_trigger("public", "users", "seq", "id",
+          time_bits: 0,
+          time_offset: 1.5,
+          data_bits: 40
+        )
+
+      assert sql =~ ", 0, 0, 0, false, 40,"
     end
 
     test "raises when encrypt_time: true and time_bits is odd" do
@@ -1093,13 +1114,10 @@ defmodule FeistelCipher.MigrationTest do
   end
 
   describe "down_for_legacy_trigger/4" do
-    test "generates SQL with safety guard" do
-      sql = FeistelCipher.down_for_legacy_trigger("public", "users", "seq", "id")
-
-      assert sql =~ "RAISE EXCEPTION"
-      assert sql =~ "DROP TRIGGER users_encrypt_seq_to_id_trigger"
-      refute sql =~ "v1_trigger"
-      assert sql =~ "public.users"
+    test "raises to prevent accidental deletion" do
+      assert_raise RuntimeError, ~r/down_for_legacy_trigger.*force_down_for_legacy_trigger/, fn ->
+        FeistelCipher.down_for_legacy_trigger("public", "users", "seq", "id")
+      end
     end
   end
 
@@ -1115,12 +1133,10 @@ defmodule FeistelCipher.MigrationTest do
   end
 
   describe "down_for_v1_trigger/4" do
-    test "generates SQL with safety guard and v1 trigger name" do
-      sql = FeistelCipher.down_for_v1_trigger("public", "users", "seq", "id")
-
-      assert sql =~ "RAISE EXCEPTION"
-      assert sql =~ "DROP TRIGGER users_encrypt_seq_to_id_v1_trigger"
-      assert sql =~ "public.users"
+    test "raises to prevent accidental deletion" do
+      assert_raise RuntimeError, ~r/down_for_v1_trigger.*force_down_for_v1_trigger/, fn ->
+        FeistelCipher.down_for_v1_trigger("public", "users", "seq", "id")
+      end
     end
   end
 

--- a/test/feistel_cipher_test.exs
+++ b/test/feistel_cipher_test.exs
@@ -969,7 +969,7 @@ defmodule FeistelCipher.MigrationTest do
           data_bits: 0
         )
 
-      assert sql =~ ", 0, false, 0,"
+      assert sql =~ ", 0, 0, 0, false, 0,"
     end
 
     test "raises when data_bits is negative" do
@@ -1025,7 +1025,7 @@ defmodule FeistelCipher.MigrationTest do
           data_bits: 40
         )
 
-      assert sql =~ ", 0, false, 40,"
+      assert sql =~ ", 0, 0, 0, false, 40,"
     end
 
     test "skips time_bucket validation when time_bits is 0" do


### PR DESCRIPTION
When `time_bits=0`, `time_bucket` and `time_offset` are now `nil` in Elixir (passed as `0` placeholder in SQL). SQL validation now only requires these fields when `time_bits > 0`.

`down_for_legacy_trigger`/`down_for_v1_trigger` now raise an Elixir exception immediately instead of returning SQL with a `DO` block. This ensures failures happen at migration authoring time rather than SQL execution time. Use `force_down_for_*` variants for intentional trigger deletion.