### PR TITLE
Remove force_down_for_*_trigger: simplify trigger drop API

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ execute FeistelCipher.up_for_trigger(
 
 ### Column Rename
 
-When renaming columns that have triggers, use `force_down_for_trigger/4` to safely drop and recreate the trigger:
+When renaming columns that have triggers, drop and recreate the trigger:
 
 ```elixir
 defmodule MyApp.Repo.Migrations.RenamePostsColumns do
@@ -242,7 +242,7 @@ defmodule MyApp.Repo.Migrations.RenamePostsColumns do
 
   def change do
     # 1. Drop the old trigger
-    execute FeistelCipher.force_down_for_trigger("public", "posts", "seq", "id")
+    execute FeistelCipher.down_for_v1_trigger("public", "posts", "seq", "id")
 
     # 2. Rename columns
     rename table(:posts), :seq, to: :sequence
@@ -252,7 +252,7 @@ defmodule MyApp.Repo.Migrations.RenamePostsColumns do
     # IMPORTANT: Generate key using OLD column names (seq, id)
     old_key = FeistelCipher.generate_key("public", "posts", "seq", "id")
 
-    execute FeistelCipher.up_for_trigger("public", "posts", "sequence", "external_id",
+    execute FeistelCipher.up_for_v1_trigger("public", "posts", "sequence", "external_id",
       time_bits: 15,               # Must match original
       time_bucket: 86400,          # Must match original
       data_bits: 38,               # Must match original
@@ -268,7 +268,7 @@ end
 - Updates will fail with exceptions
 - 1:1 mapping breaks (new inserts may produce duplicate encrypted values)
 
-> **Note**: `down_for_trigger/4` includes a safety guard (RAISE EXCEPTION) to prevent accidental deletion. For legitimate use cases like column rename, use `force_down_for_trigger/4` which bypasses the guard.
+> **⚠️ Warning**: Dropping a trigger removes encryption for that column pair. Only use this when intentionally removing or recreating the trigger.
 
 ## Alternative: Display-Only IDs
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -37,13 +37,13 @@ end
 
 4. Generate trigger migration(s):
 
-   **For Ash users**: Run `mix ash.codegen --name upgrade_feistel_triggers_to_v1`. In the generated migration's `up` function, replace `down_for_trigger` (or `down_for_v1_trigger`) with `force_down_for_legacy_trigger` to drop legacy triggers. Also in the `down` function, replace `up_for_trigger` with `up_for_legacy_trigger` and `bits:` with `time_bits: 0, data_bits:`.
+   **For Ash users**: Run `mix ash.codegen --name upgrade_feistel_triggers_to_v1`. In the generated migration's `up` function, replace `down_for_trigger` with `down_for_legacy_trigger` to drop legacy triggers. Also in the `down` function, replace `up_for_trigger` with `up_for_legacy_trigger` and `bits:` with `time_bits: 0, data_bits:`.
 
    **For plain Ecto users**: Create a separate migration to upgrade each trigger from v0.x to v1. For each table using Feistel cipher, drop the old trigger and recreate with v1:
 
    ```elixir
    # bits: N  ->  time_bits: 0, data_bits: N  (old default for bits was 52)
-   execute FeistelCipher.force_down_for_legacy_trigger("public", "posts", "seq", "id")
+   execute FeistelCipher.down_for_legacy_trigger("public", "posts", "seq", "id")
    execute FeistelCipher.up_for_v1_trigger("public", "posts", "seq", "id",
      time_bits: 0, data_bits: 52, functions_prefix: "public")
    ```

--- a/lib/upgrade.ex
+++ b/lib/upgrade.ex
@@ -84,7 +84,7 @@ if Code.ensure_loaded?(Igniter) do
 
             For Ash users:
               1. Run `mix ash.codegen --name upgrade_feistel_triggers_to_v1` to generate trigger migrations
-              2. In the generated migration's `up` function, replace `down_for_trigger` (or `down_for_v1_trigger`) with `force_down_for_legacy_trigger`
+              2. In the generated migration's `up` function, replace `down_for_trigger` with `down_for_legacy_trigger`
               3. In the `down` function, replace `up_for_trigger` with `up_for_legacy_trigger` and `bits:` with `time_bits: 0, data_bits:`
 
             For plain Ecto users:

--- a/test/feistel_cipher_test.exs
+++ b/test/feistel_cipher_test.exs
@@ -1081,10 +1081,11 @@ defmodule FeistelCipher.MigrationTest do
   end
 
   describe "down_for_legacy_trigger/4" do
-    test "raises to prevent accidental deletion" do
-      assert_raise RuntimeError, ~r/down_for_legacy_trigger.*force_down_for_legacy_trigger/, fn ->
-        FeistelCipher.down_for_legacy_trigger("public", "users", "seq", "id")
-      end
+    test "generates SQL with legacy trigger name" do
+      sql = FeistelCipher.down_for_legacy_trigger("public", "users", "seq", "id")
+
+      assert sql =~ "DROP TRIGGER users_encrypt_seq_to_id_trigger"
+      refute sql =~ "v1_trigger"
     end
   end
 
@@ -1100,25 +1101,8 @@ defmodule FeistelCipher.MigrationTest do
   end
 
   describe "down_for_v1_trigger/4" do
-    test "raises to prevent accidental deletion" do
-      assert_raise RuntimeError, ~r/down_for_v1_trigger.*force_down_for_v1_trigger/, fn ->
-        FeistelCipher.down_for_v1_trigger("public", "users", "seq", "id")
-      end
-    end
-  end
-
-  describe "force_down_for_legacy_trigger/4" do
-    test "generates SQL with legacy trigger name" do
-      sql = FeistelCipher.force_down_for_legacy_trigger("public", "users", "seq", "id")
-
-      assert sql =~ "DROP TRIGGER users_encrypt_seq_to_id_trigger"
-      refute sql =~ "v1_trigger"
-    end
-  end
-
-  describe "force_down_for_v1_trigger/4" do
     test "generates SQL with v1 trigger name" do
-      sql = FeistelCipher.force_down_for_v1_trigger("public", "users", "seq", "id")
+      sql = FeistelCipher.down_for_v1_trigger("public", "users", "seq", "id")
 
       assert sql =~ "DROP TRIGGER users_encrypt_seq_to_id_v1_trigger"
     end

--- a/test/support/migrations.ex
+++ b/test/support/migrations.ex
@@ -52,7 +52,7 @@ defmodule FeistelCipher.TestMigrations do
     end
 
     def down do
-      execute(FeistelCipher.force_down_for_legacy_trigger("public", "posts", "seq", "id"))
+      execute(FeistelCipher.down_for_legacy_trigger("public", "posts", "seq", "id"))
       drop(table(:posts))
     end
   end


### PR DESCRIPTION
- `down_for_legacy_trigger/4` and `down_for_v1_trigger/4` now return SQL string directly (same behavior as removed `force_down_for_*` variants)
- Remove `force_down_for_legacy_trigger/4` and `force_down_for_v1_trigger/4`
- Keep ⚠️ warning in docstring about encryption impact
- Update tests, README, UPGRADE.md, upgrade.ex accordingly

Made with [Cursor](https://cursor.com)