### PR TITLE
Add backfill support for encrypted columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mix igniter.install feistel_cipher
 ```elixir
 # mix.exs
 def deps do
-  [{:feistel_cipher, "~> 1.0"}]
+  [{:feistel_cipher, "~> 1.1"}]
 end
 ```
 
@@ -128,6 +128,33 @@ Now when you insert a record, `seq` auto-increments and the trigger automaticall
 ```
 
 **Security Note**: Keep `seq` internal. Only expose `id` in APIs to prevent enumeration attacks.
+
+## Backfilling Existing Rows
+
+When you add a new encrypted column to a table that already has data, use
+`backfill_for_v1_column/5` to fill rows that were inserted before the trigger
+existed.
+
+```elixir
+def up do
+  alter table(:posts) do
+    add :public_id, :bigint, default: -1
+  end
+
+  execute FeistelCipher.up_for_v1_trigger("public", "posts", "seq", "public_id",
+    time_bits: 0,
+    data_bits: 32
+  )
+
+  execute FeistelCipher.backfill_for_v1_column("public", "posts", "seq", "public_id",
+    time_bits: 0,
+    data_bits: 32
+  )
+end
+```
+
+Backfill uses an internal sentinel value of `-1`, which is safe because
+FeistelCipher only emits non-negative integers.
 
 ## ID Structure
 

--- a/lib/feistel_cipher.ex
+++ b/lib/feistel_cipher.ex
@@ -25,6 +25,8 @@ defmodule FeistelCipher do
 
   use Ecto.Migration
 
+  @backfill_sentinel -1
+
   @doc """
   Generates a cryptographically secure random salt for the Feistel cipher.
 
@@ -357,66 +359,40 @@ defmodule FeistelCipher do
   end
 
   defp do_up_for_trigger(prefix, table, from, to, opts, name_fn) do
-    time_bits = Keyword.get(opts, :time_bits, 15)
-    encrypt_time = Keyword.get(opts, :encrypt_time, false)
-    use_time_prefix = time_bits > 0
-
-    unless time_bits >= 0 do
-      raise ArgumentError, "time_bits must be non-negative, got: #{time_bits}"
-    end
-
-    if encrypt_time and rem(time_bits, 2) != 0 do
-      raise ArgumentError,
-            "time_bits must be an even number when encrypt_time is true, got: #{time_bits}"
-    end
-
-    time_bucket = Keyword.get(opts, :time_bucket, 86400)
-    time_offset = Keyword.get(opts, :time_offset, 0)
-
-    if use_time_prefix do
-      unless time_bucket > 0 do
-        raise ArgumentError, "time_bucket must be positive, got: #{time_bucket}"
-      end
-
-      unless is_integer(time_offset) do
-        raise ArgumentError, "time_offset must be an integer, got: #{inspect(time_offset)}"
-      end
-    end
-
-    data_bits = Keyword.get(opts, :data_bits, 38)
-
-    unless rem(data_bits, 2) == 0 do
-      raise ArgumentError, "data_bits must be an even number, got: #{data_bits}"
-    end
-
-    unless data_bits >= 0 do
-      raise ArgumentError, "data_bits must be non-negative, got: #{data_bits}"
-    end
-
-    max_total_bits = if encrypt_time, do: 62, else: 63
-
-    unless time_bits + data_bits <= max_total_bits do
-      raise ArgumentError,
-            "time_bits + data_bits must be <= #{max_total_bits} when encrypt_time is #{encrypt_time}, got: #{time_bits} + #{data_bits} = #{time_bits + data_bits}"
-    end
-
-    rounds = Keyword.get(opts, :rounds, 16)
-
-    unless rounds >= 1 and rounds <= 32 do
-      raise ArgumentError, "rounds must be between 1 and 32, got: #{rounds}"
-    end
-
-    key = Keyword.get(opts, :key) || generate_key(prefix, table, from, to)
-    validate_key!(key, "key")
-
-    functions_prefix = Keyword.get(opts, :functions_prefix, "public")
+    resolved_opts = resolve_cipher_options(prefix, table, from, to, opts)
 
     """
     CREATE TRIGGER #{name_fn.(table, from, to)}
       BEFORE INSERT OR UPDATE
       ON #{prefix}.#{table}
       FOR EACH ROW
-      EXECUTE PROCEDURE #{functions_prefix}.feistel_trigger_v1('#{from}', '#{to}', #{time_bits}, #{time_bucket}, #{time_offset}, #{encrypt_time}, #{data_bits}, #{key}, #{rounds});
+      EXECUTE PROCEDURE #{resolved_opts.functions_prefix}.feistel_trigger_v1('#{from}', '#{to}', #{resolved_opts.time_bits}, #{resolved_opts.time_bucket}, #{resolved_opts.time_offset}, #{resolved_opts.encrypt_time}, #{resolved_opts.data_bits}, #{resolved_opts.key}, #{resolved_opts.rounds});
+    """
+  end
+
+  @doc """
+  Returns SQL to backfill a v1 encrypted column for existing rows.
+
+  This is useful when adding a new encrypted column to a table that already has data.
+  New rows will be handled by the trigger, and this statement fills only rows where
+  the encrypted target column is currently `NULL`.
+
+  It uses the same encryption rules as `up_for_v1_trigger/5`, so you should pass the
+  exact same options used by the trigger.
+  """
+  @spec backfill_for_v1_column(String.t(), String.t(), String.t(), String.t(), keyword()) ::
+          String.t()
+  def backfill_for_v1_column(prefix, table, from, to, opts \\ []) when is_list(opts) do
+    resolved_opts = resolve_cipher_options(prefix, table, from, to, opts)
+
+    """
+    UPDATE #{prefix}.#{table}
+    SET #{to} =
+      CASE
+        WHEN #{from} IS NULL THEN NULL
+        ELSE #{encrypted_value_sql(from, resolved_opts)}
+      END
+    WHERE #{backfill_condition_sql(to)};
     """
   end
 
@@ -501,6 +477,97 @@ defmodule FeistelCipher do
 
   defp legacy_trigger_name(table, from, to) do
     "#{table}_encrypt_#{from}_to_#{to}_trigger"
+  end
+
+  defp encrypted_value_sql(from, resolved_opts) do
+    data_component_sql =
+      "#{resolved_opts.functions_prefix}.feistel_cipher_v1(#{from}, #{resolved_opts.data_bits}, #{resolved_opts.key}, #{resolved_opts.rounds})"
+
+    "(#{time_component_sql(resolved_opts)} << #{resolved_opts.data_bits}) | #{data_component_sql}"
+  end
+
+  defp time_component_sql(%{time_bits: 0}) do
+    "0"
+  end
+
+  defp time_component_sql(resolved_opts) do
+    time_value_sql =
+      "(floor((extract(epoch from now()) + #{resolved_opts.time_offset}::double precision) / #{resolved_opts.time_bucket}::double precision)::bigint & ((1::bigint << #{resolved_opts.time_bits}) - 1))"
+
+    if resolved_opts.encrypt_time do
+      "#{resolved_opts.functions_prefix}.feistel_cipher_v1(#{time_value_sql}, #{resolved_opts.time_bits}, #{resolved_opts.key}, #{resolved_opts.rounds})"
+    else
+      time_value_sql
+    end
+  end
+
+  defp backfill_condition_sql(to) do
+    "#{to} IS NULL OR #{to} = #{@backfill_sentinel}"
+  end
+
+  defp resolve_cipher_options(prefix, table, from, to, opts) do
+    time_bits = Keyword.get(opts, :time_bits, 15)
+    encrypt_time = Keyword.get(opts, :encrypt_time, false)
+    use_time_prefix = time_bits > 0
+
+    unless time_bits >= 0 do
+      raise ArgumentError, "time_bits must be non-negative, got: #{time_bits}"
+    end
+
+    if encrypt_time and rem(time_bits, 2) != 0 do
+      raise ArgumentError,
+            "time_bits must be an even number when encrypt_time is true, got: #{time_bits}"
+    end
+
+    time_bucket = Keyword.get(opts, :time_bucket, 86400)
+    time_offset = Keyword.get(opts, :time_offset, 0)
+
+    if use_time_prefix do
+      unless time_bucket > 0 do
+        raise ArgumentError, "time_bucket must be positive, got: #{time_bucket}"
+      end
+
+      unless is_integer(time_offset) do
+        raise ArgumentError, "time_offset must be an integer, got: #{inspect(time_offset)}"
+      end
+    end
+
+    data_bits = Keyword.get(opts, :data_bits, 38)
+
+    unless rem(data_bits, 2) == 0 do
+      raise ArgumentError, "data_bits must be an even number, got: #{data_bits}"
+    end
+
+    unless data_bits >= 0 do
+      raise ArgumentError, "data_bits must be non-negative, got: #{data_bits}"
+    end
+
+    max_total_bits = if encrypt_time, do: 62, else: 63
+
+    unless time_bits + data_bits <= max_total_bits do
+      raise ArgumentError,
+            "time_bits + data_bits must be <= #{max_total_bits} when encrypt_time is #{encrypt_time}, got: #{time_bits} + #{data_bits} = #{time_bits + data_bits}"
+    end
+
+    rounds = Keyword.get(opts, :rounds, 16)
+
+    unless rounds >= 1 and rounds <= 32 do
+      raise ArgumentError, "rounds must be between 1 and 32, got: #{rounds}"
+    end
+
+    key = Keyword.get(opts, :key) || generate_key(prefix, table, from, to)
+    validate_key!(key, "key")
+
+    %{
+      time_bits: time_bits,
+      time_bucket: time_bucket,
+      time_offset: time_offset,
+      encrypt_time: encrypt_time,
+      data_bits: data_bits,
+      key: key,
+      rounds: rounds,
+      functions_prefix: Keyword.get(opts, :functions_prefix, "public")
+    }
   end
 
   defp validate_key!(key, name) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FeistelCipher.MixProject do
   def project do
     [
       app: :feistel_cipher,
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       consolidate_protocols: Mix.env() not in [:dev, :test],

--- a/test/feistel_cipher_test.exs
+++ b/test/feistel_cipher_test.exs
@@ -1107,4 +1107,35 @@ defmodule FeistelCipher.MigrationTest do
       assert sql =~ "DROP TRIGGER users_encrypt_seq_to_id_v1_trigger"
     end
   end
+
+  describe "backfill_for_v1_column/5" do
+    test "generates SQL that updates null target rows only" do
+      sql = FeistelCipher.backfill_for_v1_column("public", "users", "seq", "id")
+
+      assert sql =~ "UPDATE public.users"
+      assert sql =~ "SET id ="
+      assert sql =~ "WHERE id IS NULL OR id = -1"
+      assert sql =~ "public.feistel_cipher_v1(seq, 38,"
+    end
+
+    test "includes encrypted time component when configured" do
+      sql =
+        FeistelCipher.backfill_for_v1_column("public", "users", "seq", "id",
+          time_bits: 14,
+          time_bucket: 86_400,
+          time_offset: 21_600,
+          encrypt_time: true,
+          data_bits: 38,
+          key: 12_345,
+          rounds: 8,
+          functions_prefix: "crypto"
+        )
+
+      assert sql =~
+               "crypto.feistel_cipher_v1((floor((extract(epoch from now()) + 21600::double precision) / 86400::double precision)::bigint & ((1::bigint << 14) - 1)), 14, 12345, 8)"
+
+      assert sql =~ "<< 38"
+      assert sql =~ "crypto.feistel_cipher_v1(seq, 38, 12345, 8)"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Add backfill support for encrypted columns and release it as v1.1.0.

## What changed
- add `FeistelCipher.backfill_for_v1_column/5`
- share trigger/backfill option resolution logic
- use an internal `-1` sentinel when backfilling existing rows
- add migration tests for backfill SQL generation
- document the backfill workflow in the README
- bump the package version to `1.1.0`

## Why
Adding a new encrypted column to a table with existing rows previously had no built-in backfill path. New rows could be handled by triggers, but existing rows needed manual SQL.

## Validation
- `mix test test/feistel_cipher_test.exs`
